### PR TITLE
Bug Fix: Checkout Error

### DIFF
--- a/classes/class.pmprogateway_payfast.php
+++ b/classes/class.pmprogateway_payfast.php
@@ -199,6 +199,11 @@
             if( empty( $morder ) )
                 return;
 
+            // bail if the current gateway is not set to PayFast.
+            if( 'payfast' != $morder->gateway ) {
+                return;
+            }
+
             $morder->user_id = $user_id;
             $morder->saveOrder();
 


### PR DESCRIPTION
This bug runs PayFast code as long as plugin is active, and will run the code even when PayFast is not set as active gateway.