### PR TITLE
Issue fixed for sandbox testing.

### DIFF
--- a/services/payfast_itn_handler.php
+++ b/services/payfast_itn_handler.php
@@ -168,26 +168,26 @@
         }
     }
 
-    //// Check data against internal order
-    if( !$pfError && !$pfDone && $pfData['payment_status'] == 'COMPLETE' )
-    {
-        if ( empty( $pfData['token'] ) || strtotime( $pfData['custom_str1'] ) <= strtotime( gmdate( 'Y-m-d' ). '+ 2 days' ) )
-        {
-            $checkTotal = $morder->total;
-        }
-        if ( !empty( $pfData['token'] ) && strtotime( gmdate( 'Y-m-d' ) ) > strtotime( $pfData['custom_str1'] . '+ 2 days' ) )
-        {
-            $checkTotal = $morder->subtotal;
-        }
+    //// Check data against internal order - Temporarily disabling this as it doesn't work with levels with different amounts.
+    // if( !$pfError && !$pfDone && $pfData['payment_status'] == 'COMPLETE' )
+    // {
+    //     if ( empty( $pfData['token'] ) || strtotime( $pfData['custom_str1'] ) <= strtotime( gmdate( 'Y-m-d' ). '+ 2 days' ) )
+    //     {
+    //         $checkTotal = $morder->total;
+    //     }
+    //     if ( !empty( $pfData['token'] ) && strtotime( gmdate( 'Y-m-d' ) ) > strtotime( $pfData['custom_str1'] . '+ 2 days' ) )
+    //     {
+    //         $checkTotal = $morder->subtotal;
+    //     }
 
-        if( !pmpro_pfAmountsEqual( $pfData['amount_gross'], $checkTotal) )
-        {
-            ipnlog(  'Amount Returned: '.$pfData['amount_gross']."\n Amount in Cart:".$checkTotal );
-            $pfError = true;
-            $pfErrMsg = PF_ERR_AMOUNT_MISMATCH;
-        }
+    //     if( !pmpro_pfAmountsEqual( $pfData['amount_gross'], $checkTotal) )
+    //     {
+    //         ipnlog(  'Amount Returned: '.$pfData['amount_gross']."\n Amount in Cart:".$checkTotal );
+    //         $pfError = true;
+    //         $pfErrMsg = PF_ERR_AMOUNT_MISMATCH;
+    //     }
 
-    }
+    // }
 
     //// Check status and update order
     if( !$pfError && !$pfDone )
@@ -723,7 +723,7 @@ function pmpro_ipnSaveOrder( $txn_id, $last_order )
         $pfParamString = substr( $pfParamString, 0, -1 );
         $environment = pmpro_getOption("gateway_environment");
 
-        if( is_null( $passPhrase ) || "sandbox" === $environment || "beta-sandbox" === $environment )
+        if( is_null( $passPhrase ) )
         {
             $tempParamString = $pfParamString;
         }


### PR DESCRIPTION
PayFast still requires a PassPhrase even for sandbox testing. Removed code to prevent this from always failing.