### PR TITLE
BUG FIX: & would cause signature mismatch.

### DIFF
--- a/classes/class.pmprogateway_payfast.php
+++ b/classes/class.pmprogateway_payfast.php
@@ -376,7 +376,7 @@ class PMProGateway_PayFast {
 			'email_address' => $order->Email,
 			'm_payment_id'  => $order->code,
 			'amount'        => $initial_payment,
-			'item_name'     => substr( $order->membership_level->name . ' at ' . get_bloginfo( 'name' ), 0, 99 ),
+			'item_name'     => html_entity_decode( substr( $order->membership_level->name . ' at ' . get_bloginfo( 'name' ), 0, 99 ) ),
 			'custom_int1'   => $order->user_id,
 		);
 


### PR DESCRIPTION
BUG FIX: Site names that contained HTML entities such as `&` is stored as `&amp;` and would cause a signature mismatch in PayFast.