### PR TITLE
fix: Reject fixed-term discount codes for recurring membership levels

### DIFF
--- a/classes/class.pmprogateway_payfast.php
+++ b/classes/class.pmprogateway_payfast.php
@@ -285,7 +285,7 @@ class PMProGateway_PayFast {
 		$morder->saveOrder();
 
 		// if global is empty by query is available.
-		if ( empty( $discount_code) && isset( $_REQUEST['discount_code'] ) ) {
+		if ( empty( $discount_code_id ) && isset( $_REQUEST['discount_code'] ) ) {
 			$discount_code_id = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( sanitize_text_field( $_REQUEST['discount_code'] ) ) . "'" );
 		}
 


### PR DESCRIPTION
Closes #53.

Alternatively, we could have the check made in a number of other places such as the [pmpro_checkout_before_change_membership_level](https://github.com/strangerstudios/pmpro-payfast/blob/f467cbb051b31b50bc5e1700bd4aa18ec7836ebe/classes/class.pmprogateway_payfast.php#L271-L272) method.

My decision in going with the filter instead is because it offers the best UX and informs the user early on in the checkout about the invalidity of their discount code.

Are there any other gateways where the scenario we're solving here might actually be an accepted feature? I'm thinking around whether this would affect a multi-gateway set up in some way if this can be considered acceptable behavior to have a fixed-term discount on a recurring subscription.