### PR TITLE
Membership Level ITN Handler Filter Renamed

### DIFF
--- a/services/payfast_itn_handler.php
+++ b/services/payfast_itn_handler.php
@@ -304,7 +304,7 @@ function pmpro_payfast_ipnExit() {
 function pmpro_itnChangeMembershipLevel( $txn_id, &$morder ) {
 	global $wpdb;
 	// filter for level
-	$morder->membership_level = apply_filters( 'pmpro_ipnhandler_level', $morder->membership_level, $morder->user_id );
+	$morder->membership_level = apply_filters( 'pmpro_payfast_itnhandler_level', $morder->membership_level, $morder->user_id );
 	// fix expiration date
 	if ( ! empty( $morder->membership_level->expiration_number ) ) {
 		$enddate = "'" . date( 'Y-m-d', strtotime( '+ ' . $morder->membership_level->expiration_number . ' ' . $morder->membership_level->expiration_period ) ) . "'";


### PR DESCRIPTION
Running PayPal Express + PayFast results in the same filter being used (for multi-currency sites). 

Changing this filter to be Payfast specific fixes issues where PPExpress overrides the level object with empty data. 

Filter name changed from `pmpro_ipnhandler_level` to `pmpro_payfast_itnhandler_level`