### PR TITLE
Fixes Checkout field data that gets lost when coming back from gateway

### DIFF
--- a/pmpro-payfast.php
+++ b/pmpro-payfast.php
@@ -254,3 +254,31 @@ function pmpro_payfast_discount_code_result( $discount_code, $discount_code_id, 
 
 	}
 add_action( 'pmpro_applydiscountcode_return_js', 'pmpro_payfast_discount_code_result', 10, 4 );
+
+/**
+ * Store the checkout vars in the order meta before
+ * sending to Payfast
+ */
+function pmpro_payfast_before_send_to_payfast( $user_id, $morder ) {
+
+	update_pmpro_membership_order_meta( $morder->id, 'checkout_vars', $_REQUEST );
+
+}
+add_action( 'pmpro_before_send_to_payfast', 'pmpro_payfast_before_send_to_payfast', 1, 2 );
+
+/**
+ * Load the checkout vars from the order meta into the 
+ * $_REQUEST variable so that everything in the after_checkout
+ * hook can access the data 
+ */
+function pmpro_payfast_after_checkout( $user_id, $morder ) {
+
+	$checkout_vars = get_pmpro_membership_order_meta( $morder->id, 'checkout_vars', true );
+
+	if( ! empty( $checkout_vars ) ) {
+		$_REQUEST = array_merge( $_REQUEST, $checkout_vars );		
+	}
+	
+}
+add_action( 'pmpro_after_checkout', 'pmpro_payfast_after_checkout', 1, 2 );
+

--- a/pmpro-payfast.php
+++ b/pmpro-payfast.php
@@ -256,12 +256,24 @@ function pmpro_payfast_discount_code_result( $discount_code, $discount_code_id, 
 add_action( 'pmpro_applydiscountcode_return_js', 'pmpro_payfast_discount_code_result', 10, 4 );
 
 /**
- * Store the checkout vars in the order meta before
- * sending to Payfast
+ * Store the checkout vars in the order meta before sending to PayFast.
+ * 
+ * @since TBD
  */
 function pmpro_payfast_before_send_to_payfast( $user_id, $morder ) {
 
-	update_pmpro_membership_order_meta( $morder->id, 'checkout_vars', $_REQUEST );
+	$submit_values = $_REQUEST;
+
+	// We don't need to store the password fields for this fix.
+	unset( $submit_values['password'] );
+	unset( $submit_values['password2'] );
+
+	// Loop through $_REQUEST and sanitize each value
+	foreach ( $submit_values as $key => $value ) {
+		$submit_values[ $key ] = sanitize_text_field( $value );
+	}
+
+	update_pmpro_membership_order_meta( $morder->id, 'checkout_vars', $submit_values );
 
 }
 add_action( 'pmpro_before_send_to_payfast', 'pmpro_payfast_before_send_to_payfast', 1, 2 );
@@ -269,18 +281,20 @@ add_action( 'pmpro_before_send_to_payfast', 'pmpro_payfast_before_send_to_payfas
 /**
  * Load the checkout vars from the order meta into the 
  * $_REQUEST variable so that everything in the after_checkout
- * hook can access the data 
+ * hook can access the data.
+ * 
+ * @since TBD
  */
 function pmpro_payfast_after_checkout( $user_id, $morder ) {
 
 	$checkout_vars = get_pmpro_membership_order_meta( $morder->id, 'checkout_vars', true );
 
-	if( ! empty( $checkout_vars ) ) {
+	// Merge these values into $_REQUEST so that everything in the after_checkout.
+	if ( ! empty( $checkout_vars ) ) {
 		$_REQUEST = array_merge( $_REQUEST, $checkout_vars );		
 	}
 	
-	delete_pmpro_membership_order_meta( $morder->id, 'checkout_vars' ); //Delete afterwards?
+	delete_pmpro_membership_order_meta( $morder->id, 'checkout_vars' ); //Delete afterwards as we don't need it.
 	
 }
 add_action( 'pmpro_after_checkout', 'pmpro_payfast_after_checkout', 1, 2 );
-

--- a/pmpro-payfast.php
+++ b/pmpro-payfast.php
@@ -265,8 +265,13 @@ function pmpro_payfast_before_send_to_payfast( $user_id, $morder ) {
 	$submit_values = $_REQUEST;
 
 	// We don't need to store the password fields for this fix.
-	unset( $submit_values['password'] );
-	unset( $submit_values['password2'] );
+	if ( isset( $submit_values['password'] ) ) {
+		unset( $submit_values['password'] );
+	}
+
+	if ( isset( $submit_values['password2'] ) ) {
+		unset( $submit_values['password2'] );
+	}
 
 	// Loop through $_REQUEST and sanitize each value
 	foreach ( $submit_values as $key => $value ) {

--- a/pmpro-payfast.php
+++ b/pmpro-payfast.php
@@ -260,7 +260,7 @@ add_action( 'pmpro_applydiscountcode_return_js', 'pmpro_payfast_discount_code_re
  * 
  * @since TBD
  */
-function pmpro_payfast_before_send_to_payfast( $user_id, $morder ) {
+function pmpro_payfast_before_send_to_payfast_save_data( $user_id, $morder ) {
 
 	$submit_values = $_REQUEST;
 
@@ -281,7 +281,7 @@ function pmpro_payfast_before_send_to_payfast( $user_id, $morder ) {
 	update_pmpro_membership_order_meta( $morder->id, 'checkout_vars', $submit_values );
 
 }
-add_action( 'pmpro_before_send_to_payfast', 'pmpro_payfast_before_send_to_payfast', 1, 2 );
+add_action( 'pmpro_before_send_to_payfast', 'pmpro_payfast_before_send_to_payfast_save_data', 1, 2 );
 
 /**
  * Load the checkout vars from the order meta into the 
@@ -290,7 +290,7 @@ add_action( 'pmpro_before_send_to_payfast', 'pmpro_payfast_before_send_to_payfas
  * 
  * @since TBD
  */
-function pmpro_payfast_after_checkout( $user_id, $morder ) {
+function pmpro_payfast_after_checkout_clean_data( $user_id, $morder ) {
 
 	$checkout_vars = get_pmpro_membership_order_meta( $morder->id, 'checkout_vars', true );
 
@@ -302,4 +302,4 @@ function pmpro_payfast_after_checkout( $user_id, $morder ) {
 	delete_pmpro_membership_order_meta( $morder->id, 'checkout_vars' ); //Delete afterwards as we don't need it.
 	
 }
-add_action( 'pmpro_after_checkout', 'pmpro_payfast_after_checkout', 1, 2 );
+add_action( 'pmpro_after_checkout', 'pmpro_payfast_after_checkout_clean_data', 1, 2 );

--- a/pmpro-payfast.php
+++ b/pmpro-payfast.php
@@ -279,6 +279,8 @@ function pmpro_payfast_after_checkout( $user_id, $morder ) {
 		$_REQUEST = array_merge( $_REQUEST, $checkout_vars );		
 	}
 	
+	delete_pmpro_membership_order_meta( $morder->id, 'checkout_vars' ); //Delete afterwards?
+	
 }
 add_action( 'pmpro_after_checkout', 'pmpro_payfast_after_checkout', 1, 2 );
 


### PR DESCRIPTION
Ensures that custom field data doesn't get lost when leaving the site and navigating to Payfast to process payment.

Resolves #85

Steps to recreate: 

1. Create custom fields that show up during checkout
2. Fill out the fields and Submit 
3. Make payment through Payfast
4. Allow Payfast to redirect back to the site. The site needs to be live so that PF can run the pmpro_after_checkout hook
5. The checkout should be marked as success and all field data should be updated as expected