### PR TITLE
Fix erroneous cancellations after checkout.

### DIFF
--- a/services/payfast_itn_handler.php
+++ b/services/payfast_itn_handler.php
@@ -150,10 +150,16 @@ if ( ! $pfError && ! $pfDone ) {
 		$subscr_id = $pfData['token'];
 		// custom_str1 is the date of the initial order in gmt
 		if ( strtotime( $pfData['custom_str1'] ) > strtotime( gmdate( 'Y-m-d H:i:s', current_time( 'timestamp' ) ) . '- 1 day' ) ) {
-			
 			$amount = $pfData['amount_gross'];
-			// trial, get the order
-			$morder = new MemberOrder( $pfData['m_payment_id'] );
+			
+			$morder = new MemberOrder( $txn_id );
+
+			// If order is already processed, do nothing.
+			if ( $morder->status == 'success' ) {
+				pmpro_payfast_itnlog( __( 'Order already processed. Order ID: ', 'pmpro-payfast' ) . $morder->code );
+				pmpro_payfast_ipnExit();
+			}
+
 			$morder->paypal_token = $pfData['token'];
 			$morder->getMembershipLevel();
 			$morder->getUser();


### PR DESCRIPTION
* BUG FIX: Fixed an issue where PayFast is sending multiple ITNs on a single day for an order/subscription. We assumed only one ITN request would happen but that's not the case anymore.

Resolves: https://github.com/strangerstudios/pmpro-payfast/issues/104

We need to run more tests with recurring payments, we assume that if an ITN comes in on the same day for a `m_payment_id` that it's only for one order. For some reason this was causing issues and cancelling the subscription by mistake.

I am confident this fixes the issue and will be resending ITN requests in the coming days before merging this in, feel free to use it for now as it should not negatively affect checkouts.